### PR TITLE
chore: set np dependency as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "np": "^5.1.0",
     "react-native-fs": "^2.14.1"
   },
   "devDependencies": {
     "@react-native-community/cli": "^2.9.0",
-    "prettier": "^1.18.2"
+    "prettier": "^1.18.2",
+    "np": "^5.1.0"
   },
   "nativePackage": true,
   "publishConfig": {


### PR DESCRIPTION
So depending on react-native-update-apk no longer inject
np's dependencies and font assets (not sure this commit
will fix the root cause of the issue, could simply have
happened from rerunning yarn, albeit unlikely).

--

@mikehardy so much package of yours I happen to depend on! Big thanks.